### PR TITLE
fix: safely handle null pointers in thread API message processing

### DIFF
--- a/api/src/main/java/com/ke/bella/workflow/api/DifyController.java
+++ b/api/src/main/java/com/ke/bella/workflow/api/DifyController.java
@@ -1,5 +1,6 @@
 package com.ke.bella.workflow.api;
 
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -18,13 +19,11 @@ import java.util.stream.Stream;
 
 import javax.servlet.http.HttpServletRequest;
 
-import java.time.LocalDateTime;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
-import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -79,7 +78,9 @@ import com.ke.bella.workflow.utils.DifyUtils;
 import com.ke.bella.workflow.utils.JsonUtils;
 import com.ke.bella.workflow.utils.OpenAiUtils;
 import com.theokanning.openai.assistants.message.Message;
+import com.theokanning.openai.assistants.message.MessageContent;
 import com.theokanning.openai.assistants.message.MessageListSearchParameters;
+import com.theokanning.openai.assistants.message.content.Text;
 import com.theokanning.openai.service.OpenAiService;
 
 import lombok.AllArgsConstructor;
@@ -650,12 +651,28 @@ public class DifyController {
                 }
 
                 for (List<Message> groupedMessage : groupedMessages) {
+                    String query = Optional.ofNullable(groupedMessage.get(0).getContent())
+                            .filter(content -> !content.isEmpty())
+                            .map(content -> content.get(0))
+                            .map(MessageContent::getText)
+                            .map(Text::getValue)
+                            .orElse("");
+
+                    String answer = groupedMessage.subList(1, groupedMessage.size()).stream()
+                            .map(e -> Optional.ofNullable(e.getContent())
+                                    .filter(content -> !content.isEmpty())
+                                    .map(content -> content.get(0))
+                                    .map(MessageContent::getText)
+                                    .map(Text::getValue)
+                                    .orElse(""))
+                            .filter(Objects::nonNull)
+                            .collect(Collectors.joining());
+
                     DifyChatFlowRun run = DifyChatFlowRun.builder()
                             .id(groupedMessage.get(0).getId())
                             .conversation_id(groupedMessage.get(0).getThreadId())
-                            .query(groupedMessage.get(0).getContent().get(0).getText().getValue())
-                            .answer(groupedMessage.subList(1, groupedMessage.size()).stream().map(e -> e.getContent().get(0).getText().getValue())
-                                    .collect(Collectors.joining()))
+                            .query(query)
+                            .answer(answer)
                             .created_at((long) groupedMessage.get(0).getCreatedAt())
                             .workflow_run_id(Optional.ofNullable(groupedMessage.get(0).getMetadata()).map(e -> e.get("workflowRunId")).orElse(null))
                             .build();


### PR DESCRIPTION
Added Optional chain for safe content extraction from OpenAI thread messages. This prevents NullPointerException when message content, text, or value is null.

🤖 Generated with [Claude Code](https://claude.ai/code)

# Pull Request

## Description

应该是Assistants使用新版本后，对于创建时content、messages等的默认值有变动，之前取值比较粗暴，现在适配新的thread

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🔧 Configuration change

## Component

Please check the components affected by this PR:

- [ ] 🔧 API (Backend)
- [ ] 🎨 Web (Frontend)
- [ ] 🐳 Docker/Infrastructure
- [ ] 📖 Documentation
- [ ] 🧪 Tests
- [ ] 📦 Dependencies

## Testing

Please describe the tests that you ran to verify your changes:

- [ ] Unit tests pass (`npm test` / `mvn test`)
- [ ] Integration tests pass
- [ ] Manual testing completed
- [ ] Docker build successful

**Test Configuration**:
- OS: [e.g. Ubuntu 20.04]
- Node.js version: [e.g. 20.x]
- Java version: [e.g. 8]

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please add screenshots to help explain your changes.

## Additional Notes

Add any additional notes, concerns, or questions here.